### PR TITLE
Lade setspace-Paket mit onehalfspacing

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -4,7 +4,7 @@
 \usepackage[german]{babel}
 \usepackage[a4paper,top=4cm,bottom=3cm,left=4cm,right=3cm]{geometry}
 \usepackage[pdftex]{graphicx}
-\usepackage{setspace}
+\usepackage[onehalfspacing]{setspace}
 \usepackage{tabularx}
 \usepackage{booktabs}
 \usepackage{amsmath}
@@ -17,8 +17,6 @@
 
 \begin{document}
 \allowdisplaybreaks%Mathe darf auch umbrechen
-
-\onehalfspace
 
 \begin{titlepage}
 \thispagestyle{empty}


### PR DESCRIPTION
Erspart den separaten \onehalfspace Befehl.